### PR TITLE
removed inconclusive proof for Google CDN caching

### DIFF
--- a/doc/html.md
+++ b/doc/html.md
@@ -126,17 +126,15 @@ development.
 
 The Google CDN version is chosen over other potential candidates (like the 
 [jQuery CDN](http://jquery.com/download/#jquery-39-s-cdn-provided-by-maxcdn)) 
-because it's fast in absolute terms and it has the best overall 
-[penetration](http://httparchive.org/trends.php#perGlibs) which increases the 
-odds of having a copy of the library in your user's browser cache.
+because it's fast in absolute terms and is common to use.
 
-While the Google CDN is a strong default solution your site or application may 
+While the Google CDN is a strong default solution, your site or application may 
 require a different configuration. Testing your site with services like 
 [WebPageTest](http://www.webpagetest.org/) and browser tools like 
 [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) or 
 [YSlow](http://developer.yahoo.com/yslow/) will help you examine the real 
 world performance of your site and can show where you can optimize your specific 
-site or application.  
+site or application.
 
 
 ### Google Analytics Tracking Code


### PR DESCRIPTION
Perhaps the rise in [AngularJS](http://angularjs.org/)'s popularity be the real cause for the rise in popularity in ajax.googleapis.com?  Or maybe "[Sites using Google Libraries API](http://httparchive.org/trends.php#perGlibs)" rise is caused by "[Sites with Custom Fonts](http://httparchive.org/trends.php#perFonts)"?  Perhaps a revisit to see if [hitting the version lottery](https://github.com/h5bp/html5-boilerplate/pull/1327#issuecomment-14857390) is in order, but I doubt it will prove it is worth mentioning "increases the odds of having a copy of the library in your user's browser cache".

Even though I'm involved with [jsDelivr CDN](http://www.jsdelivr.com/), and I see alot of [cdnjs](http://cdnjs.com/) usage in the wild, I conclude Google's CDN is the best to use for a generic template like h5bp.  But please, an extra 1% chance of hitting cache isn't really worth it IMHO.
